### PR TITLE
移除空任务的task

### DIFF
--- a/lib/frame_separate_task.dart
+++ b/lib/frame_separate_task.dart
@@ -78,8 +78,21 @@ class FrameSeparateTaskQueue {
     if (_hasRequestedAnEventLoopCallback) return;
     _hasRequestedAnEventLoopCallback = true;
     Timer.run(() {
+      _removeIgnoreTasks();
       _runTasks();
     });
+  }
+
+  void _removeIgnoreTasks() {
+    TaskEntry headerTaskEntry;
+
+    while (_taskQueue.isNotEmpty) {
+      headerTaskEntry = _taskQueue.first;
+      if (!headerTaskEntry.canIgnore()) {
+        break;
+      }
+      _taskQueue.removeFirst();
+    }
   }
 
   // Scheduled by _ensureEventLoopCallback.
@@ -100,10 +113,11 @@ class FrameSeparateTaskQueue {
     _taskQueue.removeWhere((e) => condition(e));
   }
 
-  Future<T> scheduleTask<T>(TaskCallback<T> task, Priority priority,
+  Future<T> scheduleTask<T>(
+      TaskCallback<T> task, Priority priority, ValueGetter<bool> canIgnore,
       {String debugLabel, Flow flow, int id}) {
     final TaskEntry<T> entry =
-        TaskEntry<T>(task, priority.value, debugLabel, flow, id: id);
+        TaskEntry<T>(task, priority.value, canIgnore, debugLabel, flow, id: id);
     _addTask(entry);
     _ensureEventLoopCallback();
     return entry.completer.future;
@@ -123,7 +137,9 @@ class FrameSeparateTaskQueue {
 }
 
 class TaskEntry<T> {
-  TaskEntry(this.task, this.priority, this.debugLabel, this.flow, {this.id}) {
+  TaskEntry(
+      this.task, this.priority, this.canIgnore, this.debugLabel, this.flow,
+      {this.id}) {
     // ignore: prefer_asserts_in_initializer_lists
     assert(() {
       debugStack = StackTrace.current;
@@ -137,6 +153,7 @@ class TaskEntry<T> {
   final String debugLabel;
   final Flow flow;
   final int id;
+  final ValueGetter<bool> canIgnore;
   StackTrace debugStack;
   Completer<T> completer;
 

--- a/lib/frame_separate_task.dart
+++ b/lib/frame_separate_task.dart
@@ -84,11 +84,8 @@ class FrameSeparateTaskQueue {
   }
 
   void _removeIgnoreTasks() {
-    TaskEntry headerTaskEntry;
-
     while (_taskQueue.isNotEmpty) {
-      headerTaskEntry = _taskQueue.first;
-      if (!headerTaskEntry.canIgnore()) {
+      if (!_taskQueue.first.canIgnore()) {
         break;
       }
       _taskQueue.removeFirst();

--- a/lib/frame_separate_widget.dart
+++ b/lib/frame_separate_widget.dart
@@ -73,7 +73,7 @@ class _FrameSeparateWidgetState extends State<FrameSeparateWidget> {
           setState(() {
             result = widget.child;
           });
-      }, Priority.animation, id: widget.index);
+      }, Priority.animation, () => !mounted, id: widget.index);
     });
   }
 }


### PR DESCRIPTION
目前每一个task占用一帧时间，如果某个task的state已经unmounted，会浪费一帧的时间执行空任务,在列表快速滑动的时候出现最多。
需要在runTasks之前检查并移除taskQueue中的空任务。FIFO的Queue，从header开始遍历检查即可。