### PR TITLE
create child only when it's need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,59 @@
-## [1.0.1] - before null-safe version 
-## [1.0.2] - fix widget doesn't transform
-## [1.0.3] - remove unnecessary task
+## 3.0.1 
 
-## [2.0.0] - adapter null-safe version 
-## [2.0.1] - modify notification usage
-## [2.0.2] - fix widget doesn't transform
-## [2.0.3] - remove unnecessary task
-## [2.0.4] - improve code style
-## [2.0.5] - add export file
-## [2.0.6] - format code
+* add the `builder` to create a widget when it's need and the `child` is deprecated.
 
-## [3.0.0] - adapted 3.0
+## 3.0.0
+
+* adapted 3.0
+
+## 2.0.6 
+
+* format code
+
+## 2.0.5
+
+* add export file
+
+## 2.0.4
+
+* improve code style
+
+## 2.0.3 
+
+* remove unnecessary task
+
+## 2.0.2 
+
+* fix widget doesn't transform
+
+## 2.0.1 
+
+* modify notification usage
+
+## 2.0.0 
+
+* adapter null-safe version
+
+## 1.0.3 
+
+* remove unnecessary task
+
+## 1.0.2 
+
+* fix widget doesn't transform
+
+## 1.0.1
+
+* before null-safe version 
+
+
+
+ 
+
+
+
+
+
+
+
+

--- a/lib/src/frame_separate_widget.dart
+++ b/lib/src/frame_separate_widget.dart
@@ -15,16 +15,44 @@ class FrameSeparateWidget extends StatefulWidget {
     Key? key,
     this.index,
     this.placeHolder,
-    required this.builder,
+    @Deprecated(
+      'Migrate to builder. '
+      'This feature was deprecated after 3.0.1',
+    )
+        required this.child,
+    this.builder,
   }) : super(key: key);
 
-  final WidgetBuilder builder;
+  factory FrameSeparateWidget.builder({
+    Key? key,
+    int? index,
+    Widget? placeHolder,
+    required WidgetBuilder builder,
+  }) =>
+      FrameSeparateWidget(
+        index: index,
+        key: key,
+        placeHolder: placeHolder,
+        builder: builder,
+        child: const SizedBox.shrink(),
+      );
+
+  /// The widget below this widget in the tree.
+  @Deprecated(
+    'Migrate to builder. '
+    'This feature was deprecated after 3.0.1',
+  )
+  final Widget child;
 
   /// The placeholder widget sets components that are as close to the actual widget as possible
   final Widget? placeHolder;
 
   /// Identifies its own ID, used in a scenario where size information is stored
   final int? index;
+
+  /// Signature for a function that creates a widget.
+  /// The builder has a higher priority, prioritize using builder before child.
+  final WidgetBuilder? builder;
 
   @override
   FrameSeparateWidgetState createState() => FrameSeparateWidgetState();
@@ -70,10 +98,11 @@ class FrameSeparateWidgetState extends State<FrameSeparateWidget> {
   void transformWidget() {
     SchedulerBinding.instance.addPostFrameCallback((Duration t) {
       FrameSeparateTaskQueue.instance!.scheduleTask(() {
-        if (mounted)
+        if (mounted) {
           setState(() {
-            result = widget.builder(context);
+            result = widget.builder?.call(context) ?? widget.child;
           });
+        }
       }, Priority.animation, () => !mounted, id: widget.index);
     });
   }

--- a/lib/src/frame_separate_widget.dart
+++ b/lib/src/frame_separate_widget.dart
@@ -15,10 +15,10 @@ class FrameSeparateWidget extends StatefulWidget {
     Key? key,
     this.index,
     this.placeHolder,
-    required this.child,
+    required this.builder,
   }) : super(key: key);
 
-  final Widget child;
+  final WidgetBuilder builder;
 
   /// The placeholder widget sets components that are as close to the actual widget as possible
   final Widget? placeHolder;
@@ -72,7 +72,7 @@ class FrameSeparateWidgetState extends State<FrameSeparateWidget> {
       FrameSeparateTaskQueue.instance!.scheduleTask(() {
         if (mounted)
           setState(() {
-            result = widget.child;
+            result = widget.builder(context);
           });
       }, Priority.animation, () => !mounted, id: widget.index);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: keframe
 description: Helps you improve the fluency of Flutter's app for any scenario
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/LianjiaTech/keframe
 
 environment:


### PR DESCRIPTION
在普通场景下，widget 的创建是廉价的，但是快速滑动的时候，并不是每个item 都会被创建。最近做热更新，widget 的创建需要跟 js 交互，这个是很昂贵的。不管是普通场景还是 widget 创建昂贵的场景，只有当 result 需要被创建的时候才去创建才是更合理的。